### PR TITLE
Fullfill refinement rules

### DIFF
--- a/py3dtiles/export.py
+++ b/py3dtiles/export.py
@@ -80,7 +80,7 @@ class Node():
             },
             "geometricError": error,  # TODO
             "children": [n.to_tileset_r(error / 2.) for n in self.children],
-            "refine": "add"
+            "refine": "ADD"
         }
         if len(self.features) != 0:
             tile["content"] = {


### PR DESCRIPTION
Prevent message regarding the refinement rules of 3D Tiles: `This tile uses a lowercase refine "add". Instead use "ADD".` 