### PR TITLE
Export valid gltf objects

### DIFF
--- a/py3dtiles/export.py
+++ b/py3dtiles/export.py
@@ -177,12 +177,14 @@ def arrays2tileset(positions, normals, bboxes, transform, ids=None, doubleSided=
                 pos = feature.index
                 binarrays.append({
                     'position': positions[pos],
-                    'normal': normals[pos],
+                    'normal': normals[pos][1],
                     'bbox': [[float(i) for i in j] for j in bboxes[pos]],
                 })
                 if ids is not None:
                     gids.append(ids[pos])
-            gltf = GlTF.from_binary_arrays(binarrays, identity, doubleSided=doubleSided)
+            gltf = GlTF.from_binary_arrays(binarrays, identity,
+                                           doubleSided=doubleSided,
+                                           nMaxMin=normals[pos][0])
             bt = None
             if ids is not None:
                 ft = FeatureTable()

--- a/py3dtiles/wkb_utils.py
+++ b/py3dtiles/wkb_utils.py
@@ -91,7 +91,8 @@ class TriangleSoup:
 
         Returns
         -------
-        Binary array of vertice normals
+        Array of min and max of vertice normals and binary array of
+        vertice normals
         """
         normals = []
         for t in self.triangles[0]:
@@ -105,7 +106,18 @@ class TriangleSoup:
                 normals.append(N / norm)
 
         verticeArray = faceAttributeToArray(normals)
-        return b''.join(verticeArray)
+        lx = []
+        ly = []
+        lz = []
+        for t in verticeArray:
+            lx.append(t[0])
+            ly.append(t[1])
+            lz.append(t[2])
+
+        nMinMax = [[np.max(lx), np.max(ly), np.max(lz)],
+                   [np.min(lx), np.min(ly), np.min(lz)]]
+
+        return [nMinMax, b''.join(verticeArray)]
 
     def getBbox(self):
         """

--- a/tests/test_b3dm.py
+++ b/tests/test_b3dm.py
@@ -37,7 +37,7 @@ class TestTileContentBuilder(unittest.TestCase):
                [8.8036420000717, 7.29930999968201, 2.05386103222656]]
         arrays = [{
             'position': positions,
-            'normal': normals,
+            'normal': normals[1],
             'bbox': box
         }]
 
@@ -54,7 +54,7 @@ class TestTileContentBuilder(unittest.TestCase):
         # get an array
         t.to_array()
         self.assertEqual(t.header.version, 1.0)
-        self.assertEqual(t.header.tile_byte_length, 2952)
+        self.assertEqual(t.header.tile_byte_length, 2860)
         self.assertEqual(t.header.ft_json_byte_length, 0)
         self.assertEqual(t.header.ft_bin_byte_length, 0)
         self.assertEqual(t.header.bt_json_byte_length, 0)
@@ -78,7 +78,7 @@ class TestTexturedTileBuilder(unittest.TestCase):
                [10, 10, 0]]
         arrays = [{
             'position': positions,
-            'normal': normals,
+            'normal': normals[1],
             'uv': uvs,
             'bbox': box
         }]
@@ -95,7 +95,7 @@ class TestTexturedTileBuilder(unittest.TestCase):
         # get an array
         t.to_array()
         self.assertEqual(t.header.version, 1.0)
-        self.assertEqual(t.header.tile_byte_length, 1556)
+        self.assertEqual(t.header.tile_byte_length, 1492)
         self.assertEqual(t.header.ft_json_byte_length, 0)
         self.assertEqual(t.header.ft_bin_byte_length, 0)
         self.assertEqual(t.header.bt_json_byte_length, 0)


### PR DESCRIPTION
- Creates valid gltf objects and uses calculated max/min for normals
- Uses the right order for max/min of vertices in the acessors configuration
- Removes unneeded default matrix
- Uses adjusted tests for the above named changes

@annarieger @weskamm @dnlkoch please take note